### PR TITLE
Fixes #14. Collects latest version of libraries

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ jupyter==1.0.0
 jupyter-client==5.2.3
 jupyter-console==5.2.0
 jupyter-core==4.4.0
-MarkupSafe==1.0
+MarkupSafe>=1.0
 mistune==0.8.3
 monotonic==1.5
 msgpack==0.5.6
@@ -83,6 +83,6 @@ ujson==1.35
 urllib3==1.23
 wcwidth==0.1.7
 webencodings==0.5.1
-Werkzeug==0.14.1
+Werkzeug>=0.14.1
 widgetsnbextension==3.4.2
 wrapt==1.10.11


### PR DESCRIPTION
It is not a good idea to write almost every library inside `pip freeze` command and especially with a `==` sign as it will give issues when an upgraded library is present.